### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     methods,
     RcppParallel,
     Rcpp (>= 0.12.0),
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.0.0),
     tidyverse,
     dplyr,
@@ -44,8 +44,8 @@ LinkingTo:
     BH (>= 1.66.0),
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0),
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0),
     RcppParallel
 SystemRequirements: GNU make
 Suggests: 

--- a/inst/stan/APCmodel.stan
+++ b/inst/stan/APCmodel.stan
@@ -3,16 +3,16 @@
 data {
    int<lower = 1> J;                    // number of age categories
   int<lower = 1> T;                    // number of years
-  int d[J*T];                          // vector of deaths
+  array[J*T] int d;                          // vector of deaths
   vector[J* T] e;                      // vector of exposures
   int<lower = 1> Tfor;                  // number of forecast years
    int<lower = 0> Tval;                  // number of validation years
-  int dval[J*Tval];                     // vector of deaths for validation
+  array[J*Tval] int dval;                     // vector of deaths for validation
   vector[J* Tval] eval;                 // vector of exposures for validation
   int<lower=0,upper=1> family;          // family = 0 for Poisson, 1 for NB
 }
 transformed data {
-  vector[J * T] offset = log(e);        // log exposures
+  vector[J * T] input_offset = log(e);        // log exposures
   vector[J * Tval] offset2 = log(eval);     // log exposures for validation
   int<lower = 1> C;                     // index for the cohort parameter
   int<lower = 1> L;                     // size of prediction vector
@@ -20,7 +20,7 @@ transformed data {
   L=J*Tfor;
 }
 parameters {
-  real<lower=0> aux[family > 0];      // neg. binomial inverse dispersion parameter
+  array[family > 0] real<lower=0> aux;      // neg. binomial inverse dispersion parameter
   vector[J] a;                         // alpha_x
 
   real c;                           // drift term
@@ -30,7 +30,7 @@ parameters {
   real psi2;
   vector[C-2] gs;                       //vector of gamma
 
-  real<lower = 0> sigma[2];            // standard deviation for the random walk and AR(2) process
+  array[2] real<lower = 0> sigma;            // standard deviation for the random walk and AR(2) process
 }
 transformed parameters {      // This block defines a new vector where the first component of kappa and the first and last component of gamma is zero, this is required for identifiability of the RH model. Otherwise, the chains will not converge.
   vector[T] k;
@@ -48,7 +48,7 @@ model {
   vector[J * T] mu; // force of mortality
   int pos = 1;
   for (t in 1:T) for (x in 1:J) {
-    mu[pos] = offset[pos]+ a[x] + k[t]+g[t-x+J];         // Predictor dynamics
+    mu[pos] = input_offset[pos]+ a[x] + k[t]+g[t-x+J];         // Predictor dynamics
     pos += 1;
   }
 
@@ -101,7 +101,7 @@ generated quantities {
   }
   mufor = exp(mufor);
   for (t in 1:T) for (x in 1:J) {
-    log_lik[pos2] = poisson_log_lpmf (d[pos2] | offset[pos2]+ a[x] + k[t]+g[t-x+J]);
+    log_lik[pos2] = poisson_log_lpmf (d[pos2] | input_offset[pos2]+ a[x] + k[t]+g[t-x+J]);
      pos2 += 1;
 }
 
@@ -112,7 +112,7 @@ generated quantities {
   }
   else if (family > 0){
     for (t in 1:Tfor) for (x in 1:J) {
-      if ( fabs(a[x] + k_p[t]+gf[T+t-x+J])>15   ){
+      if ( abs(a[x] + k_p[t]+gf[T+t-x+J])>15   ){
          mufor[pos] = 0;
     pos += 1;
       } else {
@@ -121,7 +121,7 @@ generated quantities {
           }
   }
   for (t in 1:T) for (x in 1:J) {
-     log_lik[pos2] = neg_binomial_2_log_lpmf (d[pos2] | offset[pos2]+ a[x] + k[t]+g[t-x+J],phi);
+     log_lik[pos2] = neg_binomial_2_log_lpmf (d[pos2] | input_offset[pos2]+ a[x] + k[t]+g[t-x+J],phi);
      pos2 += 1;
 }
 

--- a/inst/stan/M6model.stan
+++ b/inst/stan/M6model.stan
@@ -3,17 +3,17 @@
 data {
   int<lower = 1> J;                    // number of age categories
   int<lower = 1> T;                    // number of years
-  int d[J*T];                          // vector of deaths
+  array[J*T] int d;                          // vector of deaths
   vector[J* T] e;                      // vector of exposures
   vector[J] age;                        // vector of ages
   int<lower = 1> Tfor;                  // number of forecast years
    int<lower = 0> Tval;                  // number of validation years
-  int dval[J*Tval];                     // vector of deaths for validation
+  array[J*Tval] int dval;                     // vector of deaths for validation
   vector[J* Tval] eval;                 // vector of exposures for validation
   int<lower=0,upper=1> family;          // family = 0 for Poisson, 1 for NB
 }
 transformed data {
-  vector[J * T] offset = log(e);
+  vector[J * T] input_offset = log(e);
   vector[J * Tval] offset2 = log(eval);
   int<lower = 1> C;                     // index for the cohort parameter
   int<lower = 1> L;
@@ -21,10 +21,10 @@ transformed data {
   L=J*Tfor;
 }
 parameters {
-  real<lower=0> aux[family > 0]; // neg. binomial dispersion parameter
+  array[family > 0] real<lower=0> aux; // neg. binomial dispersion parameter
   real c1;                           // drift term for kappa_1
   real c2;                           // drift term for kappa_2
-  real<lower = 0> sigma[3];            // standard deviations for kappa_1 and kappa_2
+  array[3] real<lower = 0> sigma;            // standard deviations for kappa_1 and kappa_2
   vector[T] k;                          // vector of kappa_1
   vector[T] k2;                          // vector of kappa_2
   real<lower=-1,upper=1> rho;
@@ -47,7 +47,7 @@ model {
   vector[J * T] mu;
   int pos = 1;
   for (t in 1:T) for (x in 1:J) {
-    mu[pos] = offset[pos]+k[t]+(age[x]-mean(age))*k2[t]+g[t-x+J];      //Predictor dynamics
+    mu[pos] = input_offset[pos]+k[t]+(age[x]-mean(age))*k2[t]+g[t-x+J];      //Predictor dynamics
     pos += 1;
   }
 
@@ -108,7 +108,7 @@ generated quantities {
   }
   mufor=exp(mufor);
   for (t in 1:T) for (x in 1:J) {
-    log_lik[pos2] = poisson_log_lpmf (d[pos2] | offset[pos2]+ k[t]+(age[x]-mean(age))*k2[t]+g[t-x+J]);
+    log_lik[pos2] = poisson_log_lpmf (d[pos2] | input_offset[pos2]+ k[t]+(age[x]-mean(age))*k2[t]+g[t-x+J]);
      pos2 += 1;
 }
 
@@ -119,7 +119,7 @@ generated quantities {
   }
   else if (family > 0){
      for (t in 1:Tfor) for (x in 1:J) {
-      if ( fabs(k_p[t]+(age[x]-mean(age))*k2_p[t]+gf[T+t-x+J])>15   ){
+      if ( abs(k_p[t]+(age[x]-mean(age))*k2_p[t]+gf[T+t-x+J])>15   ){
          mufor[pos] = 0;
     pos += 1;
       } else {
@@ -128,7 +128,7 @@ generated quantities {
           }
   }
   for (t in 1:T) for (x in 1:J) {
-     log_lik[pos2] = neg_binomial_2_log_lpmf (d[pos2] | offset[pos2]+ k[t]+(age[x]-mean(age))*k2[t]+g[t-x+J],phi);
+     log_lik[pos2] = neg_binomial_2_log_lpmf (d[pos2] | input_offset[pos2]+ k[t]+(age[x]-mean(age))*k2[t]+g[t-x+J],phi);
      pos2 += 1;
 }
 

--- a/inst/stan/RHmodel.stan
+++ b/inst/stan/RHmodel.stan
@@ -3,16 +3,16 @@
 data {
    int<lower = 1> J;                    // number of age categories
   int<lower = 1> T;                    // number of years
-  int d[J*T];                          // vector of deaths
+  array[J*T] int d;                          // vector of deaths
   vector[J* T] e;                      // vector of exposures
   int<lower = 1> Tfor;                  // number of forecast years
   int<lower = 0> Tval;                  // number of validation years
-  int dval[J*Tval];                     // vector of deaths for validation
+  array[J*Tval] int dval;                     // vector of deaths for validation
   vector[J* Tval] eval;                 // vector of exposures for validation
   int<lower=0,upper=1> family;          // family = 0 for Poisson, 1 for NB
 }
 transformed data {
-  vector[J * T] offset = log(e);        // log exposures
+  vector[J * T] input_offset = log(e);        // log exposures
   vector[J * Tval] offset2 = log(eval);     // log exposures for validation
   int<lower = 1> C;                     // index for the cohort parameter
   int<lower = 1> L;                     // size of prediction vector
@@ -20,7 +20,7 @@ transformed data {
   L=J*Tfor;
 }
 parameters {
-  real<lower=0> aux[family > 0];      // neg. binomial dispersion parameter
+  array[family > 0] real<lower=0> aux;      // neg. binomial dispersion parameter
   vector[J] a;                         // alpha_x
   simplex[J] b;                        // beta_x, strictly positive and sums to 1
 
@@ -32,7 +32,7 @@ parameters {
   real psi2;
   vector[C-3] gs;                       //vector of gamma
 
-  real<lower = 0> sigma[2];            // standard deviation for the random walk and AR(2) process
+  array[2] real<lower = 0> sigma;            // standard deviation for the random walk and AR(2) process
 }
 transformed parameters {      // This block defines a new vector where the first component of kappa and the first and last components of gamma is zero, this is required for identifiability of the RH model. Otherwise, the chains will not converge.
   vector[T] k;
@@ -51,7 +51,7 @@ model {
   vector[J * T] mu; //force of mortality
   int pos = 1;
   for (t in 1:T) for (x in 1:J) {
-    mu[pos] = offset[pos]+ a[x] + b[x]*k[t]+g[t-x+J];         // Predictor dynamics
+    mu[pos] = input_offset[pos]+ a[x] + b[x]*k[t]+g[t-x+J];         // Predictor dynamics
     pos += 1;
   }
   target += normal_lpdf(ks[1]|c,sigma[1]);
@@ -102,7 +102,7 @@ generated quantities {
   }
   mufor = exp(mufor);
   for (t in 1:T) for (x in 1:J) {
-    log_lik[pos2] = poisson_log_lpmf (d[pos2] | offset[pos2]+ a[x] + b[x] * k[t]+g[t-x+J]);
+    log_lik[pos2] = poisson_log_lpmf (d[pos2] | input_offset[pos2]+ a[x] + b[x] * k[t]+g[t-x+J]);
      pos2 += 1;
 }
 
@@ -113,7 +113,7 @@ generated quantities {
   }
   else if (family > 0){
     for (t in 1:Tfor) for (x in 1:J) {
-      if ( fabs(a[x] + b[x] * k_p[t]+gf[T+t-x+J])>15   ){
+      if ( abs(a[x] + b[x] * k_p[t]+gf[T+t-x+J])>15   ){
          mufor[pos] = 0;
     pos += 1;
       } else {
@@ -122,7 +122,7 @@ generated quantities {
           }
   }
   for (t in 1:T) for (x in 1:J) {
-     log_lik[pos2] = neg_binomial_2_log_lpmf (d[pos2] | offset[pos2]+ a[x] + b[x] * k[t]+g[t-x+J],phi);
+     log_lik[pos2] = neg_binomial_2_log_lpmf (d[pos2] | input_offset[pos2]+ a[x] + b[x] * k[t]+g[t-x+J],phi);
      pos2 += 1;
 }
 


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax
- `offset` is a reserved keyword, changed to `input_offset`
- `fabs` replaced by `abs`

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
